### PR TITLE
Toevoegen van stoelenreserveringssysteem, beschrijving en filmzaal

### DIFF
--- a/DataModels/FilmModel.cs
+++ b/DataModels/FilmModel.cs
@@ -20,18 +20,22 @@ public class FilmModel
     [JsonPropertyName("filmTime")]
     public string filmTime { get; set; }
 
+    [JsonPropertyName("filmRoom")]
+    public string filmRoom { get; set; }
+
     public FilmModel()
     {
         Id = NextId();
     }
     
-    public FilmModel(string filmname, string filmdescription, string filmdate, string filmtime)
+    public FilmModel(string filmname, string filmdescription, string filmdate, string filmtime, string filmroom)
     {
         Id = CurrentId;
         filmName = filmname;
         filmDescription = filmdescription;
         filmDate = filmdate;
         filmTime = filmtime;
+        filmRoom = filmroom;
 
         _nextId = Id + 1;
     }

--- a/DataModels/FilmModel.cs
+++ b/DataModels/FilmModel.cs
@@ -11,6 +11,9 @@ public class FilmModel
     [JsonPropertyName("filmName")]
     public string filmName { get; set; }
 
+    [JsonPropertyName("filmDescription")]
+    public string filmDescription { get; set; }
+
     [JsonPropertyName("filmDate")]
     public string filmDate { get; set; }
 
@@ -22,10 +25,11 @@ public class FilmModel
         Id = NextId();
     }
     
-    public FilmModel(string filmname, string filmdate, string filmtime)
+    public FilmModel(string filmname, string filmdescription, string filmdate, string filmtime)
     {
         Id = CurrentId;
         filmName = filmname;
+        filmDescription = filmdescription;
         filmDate = filmdate;
         filmTime = filmtime;
 

--- a/DataSources/films.json
+++ b/DataSources/films.json
@@ -4,7 +4,7 @@
     "filmName": "test1",
     "filmDescription": "Dit is test1",
     "filmDate": "12-12-2003",
-    "filmTime": "12:12",
+    "filmTime": "12:00",
     "filmRoom": "1"
   },
   {
@@ -14,5 +14,13 @@
     "filmDate": "17-12-2005",
     "filmTime": "21:12",
     "filmRoom": "2"
+  },
+  {
+    "id": 3,
+    "filmName": "test1",
+    "filmDescription": "Dit is test3",
+    "filmDate": "12-12-2003",
+    "filmTime": "12:30",
+    "filmRoom": "1"
   }
 ]

--- a/DataSources/films.json
+++ b/DataSources/films.json
@@ -2,55 +2,29 @@
   {
     "id": 1,
     "filmName": "test1",
+    "filmDescription": "Dit is test1",
     "filmDate": "12-12-2003",
     "filmTime": "12:12"
   },
   {
     "id": 2,
-    "filmName": "test1",
+    "filmName": "test2",
+    "filmDescription": "Dit is test2",
     "filmDate": "17-12-2005",
     "filmTime": "21:12"
   },
   {
     "id": 3,
-    "filmName": "test1",
+    "filmName": "test3",
+    "filmDescription": "Dit is test3",
     "filmDate": "29-12-2008",
     "filmTime": "13:13"
   },
   {
     "id": 4,
-    "filmName": "test2",
-    "filmDate": "31-12-2020",
-    "filmTime": "23:59"
-  },
-  {
-    "id": 5,
-    "filmName": "test2",
-    "filmDate": "01-01-2030",
-    "filmTime": "23:13"
-  },
-  {
-    "id": 6,
-    "filmName": "test3",
-    "filmDate": "02-02-2000",
-    "filmTime": "01:10"
-  },
-  {
-    "id": 7,
-    "filmName": "abcdef",
-    "filmDate": "02-02-2000",
-    "filmTime": "01:10"
-  },
-  {
-    "id": 8,
-    "filmName": "test123",
-    "filmDate": "12-12-2040",
-    "filmTime": "13:13"
-  },
-  {
-    "id": 9,
-    "filmName": "test123",
-    "filmDate": "12-12-2003",
-    "filmTime": "12:12"
+    "filmName": "test0",
+    "filmDescription": "Dit is een beschrijving van test0",
+    "filmDate": "13-12-2011",
+    "filmTime": "13:19"
   }
 ]

--- a/DataSources/films.json
+++ b/DataSources/films.json
@@ -4,27 +4,15 @@
     "filmName": "test1",
     "filmDescription": "Dit is test1",
     "filmDate": "12-12-2003",
-    "filmTime": "12:12"
+    "filmTime": "12:12",
+    "filmRoom": "1"
   },
   {
     "id": 2,
     "filmName": "test2",
     "filmDescription": "Dit is test2",
     "filmDate": "17-12-2005",
-    "filmTime": "21:12"
-  },
-  {
-    "id": 3,
-    "filmName": "test3",
-    "filmDescription": "Dit is test3",
-    "filmDate": "29-12-2008",
-    "filmTime": "13:13"
-  },
-  {
-    "id": 4,
-    "filmName": "test0",
-    "filmDescription": "Dit is een beschrijving van test0",
-    "filmDate": "13-12-2011",
-    "filmTime": "13:19"
+    "filmTime": "21:12",
+    "filmRoom": "2"
   }
 ]

--- a/Logic/FilmLogic.cs
+++ b/Logic/FilmLogic.cs
@@ -112,9 +112,28 @@ class FilmsLogic
         }
         return true;
     }
-    public void AddFilm(string filmname, string filmdescription, string filmdate, string filmtime)
+    public bool CheckFilmRoom(string filmroom)
     {
-        FilmModel newFilm = new FilmModel(filmname, filmdescription, filmdate, filmtime);
+        // check if filmname is empty
+        if (filmroom == "")
+        {
+            WriteLine("Vul een filmzaal in");
+            return false;
+        }
+        // check filmname character length
+        if (filmroom == "1" || filmroom == "2" || filmroom == "3")
+        {
+            return true;
+        }
+        else
+        {
+            WriteLine("Je moet een geldige zaal kiezen!");
+        }
+        return false;
+    }
+    public void AddFilm(string filmname, string filmdescription, string filmdate, string filmtime, string filmroom)
+    {
+        FilmModel newFilm = new FilmModel(filmname, filmdescription, filmdate, filmtime, filmroom);
         _films.Add(newFilm);
         FilmsAccess.WriteAll(_films);
     }

--- a/Logic/FilmLogic.cs
+++ b/Logic/FilmLogic.cs
@@ -68,6 +68,22 @@ class FilmsLogic
         }
         return true;
     }
+    public bool CheckFilmDescription(string filmdescription)
+    {
+        // check if filmname is empty
+        if (filmdescription == "")
+        {
+            WriteLine("Vul een beschrijving in");
+            return false;
+        }
+        // check filmname character length
+        if (filmdescription.Length > 200)
+        {
+            WriteLine("Film beschrijving mag niet te lang zijn!");
+            return false;
+        }
+        return true;
+    }
     public bool CheckFilmDate(string filmdate)
     {
         DateTime date;
@@ -96,9 +112,9 @@ class FilmsLogic
         }
         return true;
     }
-    public void AddFilm(string filmname, string filmdate, string filmtime)
+    public void AddFilm(string filmname, string filmdescription, string filmdate, string filmtime)
     {
-        FilmModel newFilm = new FilmModel(filmname, filmdate, filmtime);
+        FilmModel newFilm = new FilmModel(filmname, filmdescription, filmdate, filmtime);
         _films.Add(newFilm);
         FilmsAccess.WriteAll(_films);
     }

--- a/Presentation/CreateMenus.cs
+++ b/Presentation/CreateMenus.cs
@@ -193,6 +193,118 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
 
     }
 
+    public void FilmSeats()
+    {
+        Clear();
+        bool running = true;
+        int currentRow = 0;
+        int currentColumn = 0;
+        int numRows = 10;
+        int numColumns = 10;
+
+        // Initialize unreserved seats
+        bool[,] seats = new bool[numRows, numColumns];
+
+        // Use list to keep track of the seats reserved
+        List<string> reservedSeats = new List<string>();
+
+        while (running) {
+            Clear();
+            WriteLine("Selecteer een stoel (gebruik de pijltjestoetsen om te bewegen, spatiebalk om te reserveren of Esc om te verlaten):");
+            WriteLine();
+
+            for (int row = 0; row < numRows; row++)
+            {
+                for (int col = 0; col < numColumns; col++)
+                {
+                    if (row == currentRow && col == currentColumn)
+                    {
+                        ForegroundColor = ConsoleColor.Green;
+                    }
+                    else if (seats[row, col])
+                    {
+                        ForegroundColor = ConsoleColor.Red;
+                    }
+                    else
+                    {
+                        ForegroundColor = ConsoleColor.White;
+                    }
+
+                    string seatNumber = "";
+
+                    // Calculate seat number based on row and column
+                    if (col < 9)
+                    {
+                        seatNumber += (char)('A' + row);
+                        seatNumber += (col + 1).ToString();
+                    }
+                    else
+                    {
+                        seatNumber += (char)('A' + row + 1);
+                        seatNumber += (col - 8).ToString();
+                    }
+
+                    Write((seats[row, col]) ? seatNumber + " " : seatNumber + " ");
+                }
+                WriteLine();
+            }
+            WriteLine();
+            // Print out reserved seats
+            WriteLine($"Gereserveerde stoelen: {string.Join(", ", reservedSeats)}");
+
+            ConsoleKeyInfo keyInfo = ReadKey(true);
+
+            switch (keyInfo.Key)
+            {
+                case ConsoleKey.UpArrow:
+                    currentRow = Math.Max(0, currentRow - 1);
+                    break;
+                case ConsoleKey.DownArrow:
+                    currentRow = Math.Min(numRows - 1, currentRow + 1);
+                    break;
+                case ConsoleKey.LeftArrow:
+                    currentColumn = Math.Max(0, currentColumn - 1);
+                    break;
+                case ConsoleKey.RightArrow:
+                    currentColumn = Math.Min(numColumns - 1, currentColumn + 1);
+                    break;
+                case ConsoleKey.Spacebar:
+                    if (!seats[currentRow, currentColumn])
+                    {
+                        seats[currentRow, currentColumn] = true;
+                        ForegroundColor = ConsoleColor.White;
+
+                        string reservedSeat = "";
+
+                        // Calculate reserved seat number based on row and column
+                        if (currentColumn < 9)
+                        {
+                            reservedSeat += (char)('A' + currentRow);
+                            reservedSeat += (currentColumn + 1).ToString();
+                        }
+                        else
+                        {
+                            reservedSeat += (char)('A' + currentRow + 1);
+                            reservedSeat += (currentColumn - 8).ToString();
+                        }
+
+                        reservedSeats.Add(reservedSeat);
+
+                        WriteLine($"Stoel {reservedSeat} gereserveerd.");
+                    }
+                    else
+                    {
+                        WriteLine($"Stoel al gereserveerd.");
+                    }
+                    break;
+                case ConsoleKey.Escape:
+                    WriteLine("Verlaten...");
+                    running = false;
+                    break;
+            }
+            WriteLine();
+        }
+    }
 
     private void Reservations()
     {

--- a/Presentation/CreateMenus.cs
+++ b/Presentation/CreateMenus.cs
@@ -323,10 +323,13 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
     {
         FilmsLogic filmslogic = new FilmsLogic();
         Clear();
+
         string ?filmname;
         string ?filmdescription;
         string ?filmdate;
         string ?filmtime;
+        string ?filmroom;
+
         WriteLine("Voeg een film toe");
         WriteLine();
         while (true)
@@ -353,8 +356,33 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
             filmtime = ReadLine();
             if (filmslogic.CheckFilmTime(filmtime)) break;
         }
+        WriteLine();
+        while (true)
+        {
+            string prompt = "Kies een filmzaal: ";
+            // There are only 3 rooms available
+            string[] options = {"Zaal 1 (150 stoelen)", "Zaal 2 (300 stoelen)", "Zaal 3 (500 stoelen)"};
+            Menu Films = new Menu(prompt, options);
+            int SelectedIndex = Films.Run();
+            switch (SelectedIndex)
+            {
+                case 0:
+                    filmroom = "1";
+                    break;
+                case 1:
+                    filmroom = "2";
+                    break;
+                case 2:
+                    filmroom = "3";
+                    break;
+                default:
+                    filmroom = "";
+                    break;
+            }
+            if (filmslogic.CheckFilmRoom(filmroom)) break;
+        }
         // Add the film
-        filmslogic.AddFilm(filmname, filmdescription, filmdate, filmtime);
+        filmslogic.AddFilm(filmname, filmdescription, filmdate, filmtime, filmroom);
         Clear();
         var temp = new CreateMenus();
         temp.FilmsAdmin();

--- a/Presentation/CreateMenus.cs
+++ b/Presentation/CreateMenus.cs
@@ -332,28 +332,19 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
             {
             WriteLine("Filmnaam: ");
             filmname = ReadLine();
-            if (filmslogic.CheckFilmName(filmname))
-            {
-                break;
-            }
+            if (filmslogic.CheckFilmName(filmname)) break;
         }
         while (true)
         {
             WriteLine("Filmdatum: ");
             filmdate = ReadLine();
-            if (filmslogic.CheckFilmDate(filmdate))
-            {
-                break;
-            }
+            if (filmslogic.CheckFilmDate(filmdate)) break;
         }
         while (true)
         {
             WriteLine("Filmtijd: ");
             filmtime = ReadLine();
-            if (filmslogic.CheckFilmTime(filmtime))
-            {
-                break;
-            }
+            if (filmslogic.CheckFilmTime(filmtime)) break;
         }
         filmslogic.AddFilm(filmname, filmdate, filmtime);
         Clear();

--- a/Presentation/CreateMenus.cs
+++ b/Presentation/CreateMenus.cs
@@ -353,6 +353,7 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
             filmtime = ReadLine();
             if (filmslogic.CheckFilmTime(filmtime)) break;
         }
+        // Add the film
         filmslogic.AddFilm(filmname, filmdescription, filmdate, filmtime);
         Clear();
         var temp = new CreateMenus();
@@ -368,13 +369,14 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
 
         string[] options = new string[0];
 
+        // Get all the films
         foreach (FilmModel allFilms in filmsLogic.GetAllFilms())
         {
             Array.Resize(ref options, options.Length + 1);
             options[options.Length - 1] = allFilms.filmName;
         }
 
-        // Shift all elements one place to the right
+        // increse the array size
         Array.Resize(ref options, options.Length + 2);
         for (int i = options.Length - 2; i >= 0; i--)
         {
@@ -384,7 +386,9 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
         // Add "Terug" at the end
         options[options.Length - 1] = "Terug";
 
+        // Remove the duplicates using hashset
         HashSet<string> hashSet = new HashSet<string>(options);
+        // Turn it back to an array
         options = hashSet.ToArray();
 
         Menu Films = new Menu(prompt, options);
@@ -402,8 +406,10 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
             switch (SelectedIndex2)
             {
                 case 0:
+                        // Use the name of the selected option to get the film info
                         while (filmsLogic.GetByName(options[SelectedIndex]) != null)
                         {
+                            // Delete the film that is selected
                             filmsLogic.DeleteFilm(filmsLogic.GetByName(options[SelectedIndex]));
                         }
                         AdminRemoveFilm();

--- a/Presentation/CreateMenus.cs
+++ b/Presentation/CreateMenus.cs
@@ -294,7 +294,24 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
                     }
                     else
                     {
-                        WriteLine($"Stoel al gereserveerd.");
+                        seats[currentRow, currentColumn] = false;
+                        ForegroundColor = ConsoleColor.White;
+
+                        string reservedSeat = "";
+
+                        // Calculate reserved seat number based on row and column
+                        if (currentColumn < 9)
+                        {
+                            reservedSeat += (char)('A' + currentRow);
+                            reservedSeat += (currentColumn + 1).ToString();
+                        }
+                        else
+                        {
+                            reservedSeat += (char)('A' + currentRow + 1);
+                            reservedSeat += (currentColumn - 8).ToString();
+                        }
+
+                        reservedSeats.Remove(reservedSeat);
                     }
                     break;
                 case ConsoleKey.Escape:

--- a/Presentation/CreateMenus.cs
+++ b/Presentation/CreateMenus.cs
@@ -324,6 +324,7 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
         FilmsLogic filmslogic = new FilmsLogic();
         Clear();
         string ?filmname;
+        string ?filmdescription;
         string ?filmdate;
         string ?filmtime;
         WriteLine("Voeg een film toe");
@@ -333,6 +334,12 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
             WriteLine("Filmnaam: ");
             filmname = ReadLine();
             if (filmslogic.CheckFilmName(filmname)) break;
+        }
+        while (true)
+            {
+            WriteLine("Film beschrijving: ");
+            filmdescription = ReadLine();
+            if (filmslogic.CheckFilmDescription(filmdescription)) break;
         }
         while (true)
         {
@@ -346,7 +353,7 @@ Volg de aanwijzingen op dit scherm en ons systeem zal u door de rest leiden.";
             filmtime = ReadLine();
             if (filmslogic.CheckFilmTime(filmtime)) break;
         }
-        filmslogic.AddFilm(filmname, filmdate, filmtime);
+        filmslogic.AddFilm(filmname, filmdescription, filmdate, filmtime);
         Clear();
         var temp = new CreateMenus();
         temp.FilmsAdmin();

--- a/Program.cs
+++ b/Program.cs
@@ -5,7 +5,7 @@ class Program
     public static void Main()
     {
         CreateMenus newStart = new CreateMenus();
-        //newStart.AdminAddFilm();
-        newStart.Begin();
+        newStart.AdminMenu();
+        //newStart.Begin();
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -5,7 +5,8 @@ class Program
     public static void Main()
     {
         CreateMenus newStart = new CreateMenus();
-        newStart.AdminMenu();
+        //newStart.AdminMenu();
         //newStart.Begin();
+        newStart.FilmSeats();
     }
 }


### PR DESCRIPTION
**Deze pull request** voegt functionaliteit toe voor het **laten zien** van bioscoopstoelen. Ik ben ermee begonnen, maar er moet nog verder aan gewerkt worden. De belangrijkste toevoeging is de mogelijkheid om een stoelreservering ongedaan te maken door twee keer op de spatiebalk te drukken op een gereserveerde stoel. Hierdoor wordt de stoel weer beschikbaar en wordt deze ook verwijderd uit de lijst van gereserveerde stoelen.

Verder heb ik filmbeschrijving en filmzaal toegevoegd aan de JSON-file. Daarnaast kan de beheerder ook de filmbeschrijving en filmzaal toevoegen aan de beheerderskant.

Tevens heb ik enkele commentaarregels toegevoegd om de code beter leesbaar te maken.

**Screenshot van stoelenreservering:**
![image](https://user-images.githubusercontent.com/103484064/235363575-8216e4c3-2c4e-49a8-8284-f18036302c5f.png)